### PR TITLE
fixed assigning subscription drop reason

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -169,6 +169,10 @@ module.exports = class Client {
       }
     }
     const onSubscriptionDropped = function (subscription, reason, error) {
+      if (!error) {
+        error = new Error('Subscription dropped generic error')
+      }
+
       error.reason = reason
 
       // Notify drop at the end of the event loop to allow processing to finish


### PR DESCRIPTION
in case there is no Error passed to the `onSubscriptionDropped` callback:

```
{
    "name": "send-email-job",
    "hostname": "404586753acb",
    "pid": 23,
    "level": 50,
    "err": {
        "message": "Cannot set property 'reason' of null",
        "name": "TypeError",
        "stack": "TypeError: Cannot set property 'reason' of null\n    at EventStorePersistentSubscription.onSubscriptionDropped [as _subscriptionDropped] (/app/node_modules/@billyfree/eventstore-client/lib/client.js:172:20)\n    at EventStorePersistentSubscriptionBase._dropSubscription (/app/node_modules/@billyfree/eventstore-client/src/eventStorePersistentSubscriptionBase.js:177:14)\n    at EventStorePersistentSubscriptionBase._processQueue (/app/node_modules/@billyfree/eventstore-client/src/eventStorePersistentSubscriptionBase.js:131:10)\n    at runCallback (timers.js:810:20)\n    at tryOnImmediate (timers.js:768:5)\n    at processImmediate [as _immediateCallback] (timers.js:745:5)"
    },
    "@timestamp": "2020-11-28T13:37:00.856Z",
    "message": "Persistent Subscription to Emails: subscriptionDropped callback failed.",
    "service": "send-email-job",
    "level_name": "error"
}
```